### PR TITLE
Make sidecar default resources configurable

### DIFF
--- a/charts/telegraf-operator/Chart.yaml
+++ b/charts/telegraf-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.9
+version: 1.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/telegraf-operator/templates/deployment.yaml
+++ b/charts/telegraf-operator/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- if eq .Values.requireAnnotationsForSecret true }}
             - "--require-annotations-for-secret"
             {{- end }}
+            - "--telegraf-requests-cpu={{ .Values.sidecarResources.requests.cpu }}"
+            - "--telegraf-requests-memory={{ .Values.sidecarResources.requests.memory }}"
+            - "--telegraf-limits-cpu={{ .Values.sidecarResources.limits.cpu }}"
+            - "--telegraf-limits-memory={{ .Values.sidecarResources.limits.memory }}"
             {{- if eq .Values.hotReload true }}
             - "--telegraf-watch-config=inotify"
             {{- end }}

--- a/charts/telegraf-operator/values.yaml
+++ b/charts/telegraf-operator/values.yaml
@@ -42,6 +42,13 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
+sidecarResources:
+  limits:
+    cpu: 200m
+    memory: 200Mi
+  requests:
+    cpu: 10m
+    memory: 10Mi
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
when default sidecar resources doesn't fit someone's need it's
prefferable to specify custom default value instead of adding annotations
to every pod that runs sidecar